### PR TITLE
Format codebase

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,152 @@
+---
+Language:        Cpp
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: None
+AlignConsecutiveAssignments: None
+AlignConsecutiveBitFields: None
+AlignConsecutiveDeclarations: None
+AlignConsecutiveMacros: None
+AlignConsecutiveShortCaseStatements:
+  Enabled: false
+AlignEscapedNewlines: Left
+AlignOperands:   Align
+AlignTrailingComments: Always
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowBreakBeforeNoexceptSpecifier: Never
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortCompoundRequirementOnASingleLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: All
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakBeforeMultilineStrings: false
+BinPackArguments: true
+BinPackParameters: true
+BitFieldColonSpacing: Both
+BreakAdjacentStringLiterals: true
+BreakAfterAttributes: Leave
+BreakAfterJavaFieldAnnotations: false
+BreakAfterReturnType: Automatic
+BreakArrays:     true
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeBraces: Allman
+BreakBeforeConceptDeclarations: Always
+BreakBeforeInlineASMColon: OnlyMultiline
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeComma
+BreakInheritanceList: BeforeComma
+BreakStringLiterals: true
+BreakTemplateDeclarations: MultiLine
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+FixNamespaceComments: true
+ForEachMacros:   [foreach, Q_FOREACH, BOOST_FOREACH]
+IndentAccessModifiers: false
+IndentCaseBlocks: false
+IndentCaseLabels: false
+IndentExternBlock: Indent
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentRequiresClause: true
+IndentWidth: 4
+IndentWrappedFunctionNames: false
+InsertBraces:    false
+InsertNewlineAtEOF: true
+InsertTrailingCommas: None
+IntegerLiteralSeparator:
+  Binary:          0
+  BinaryMinDigits: 0
+  Decimal:         0
+  DecimalMinDigits: 0
+  Hex:             0
+  HexMinDigits:    0
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+KeepEmptyLinesAtEOF: false
+LambdaBodyIndentation: Signature
+LineEnding:      DeriveLF
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: All
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 4
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PackConstructorInitializers: Never
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakScopeResolution: 500
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyIndentedWhitespace: 0
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Left
+PPIndentWidth:   -1
+QualifierAlignment: Leave
+ReferenceAlignment: Pointer
+RemoveBracesLLVM: false
+RemoveParentheses: Leave
+RemoveSemicolon: false
+RequiresClausePosition: OwnLine
+RequiresExpressionIndentation: OuterScope
+SeparateDefinitionBlocks: Always
+ShortNamespaceLines: 1
+SkipMacroDefinitionBody: false
+SortIncludes: Never
+SortJavaStaticImport: Before
+SortUsingDeclarations: LexicographicNumeric
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeJsonColon: false
+SpaceBeforeParens: Custom
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   true
+  AfterOverloadedOperator: false
+  AfterPlacementOperator: true
+  AfterRequiresInClause: false
+  AfterRequiresInExpression: false
+  BeforeNonEmptyParentheses: false
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  Never
+SpacesInContainerLiterals: true
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+SpacesInParens:  Never
+SpacesInSquareBrackets: false
+Standard:        Latest
+UseTab:          Never
+...

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,10 +5,9 @@ repos:
       - id: cmake-format
 
   - repo: https://github.com/psf/black
-    rev: 22.8.0
+    rev: 24.8.0
     hooks:
       - id: black
-        language_version: python3.10
 
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: 'v19.1.4'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,8 @@ repos:
     hooks:
       - id: black
         language_version: python3.10
+
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: 'v19.1.4'
+    hooks:
+      - id: clang-format

--- a/Reader.cpp
+++ b/Reader.cpp
@@ -20,74 +20,97 @@
 #include <WFObj/Reader.h>
 #include <fstream>
 
-extern void WFObjParse(std::istream&,WFObj::Reader*);
+extern void WFObjParse(std::istream&, WFObj::Reader*);
 
-namespace WFObj {
-using namespace std;
-
-Reader::Reader() {}
-Reader::~Reader() {}
-
-void Reader::finished() {}
-
-void Reader::v(float x,float y,float z) {}
-void Reader::v(float x,float y,float z,float w) { v(x,y,z); }
-void Reader::vt(float) {}
-void Reader::vt(float,float) {}
-void Reader::vt(float,float,float) {}
-void Reader::vn(float,float,float) {}
-void Reader::vp(float,float) {}
-void Reader::vp(float) {}
-void Reader::f(const Reader::VertexIndices&, 
-	       const Reader::NormalIndices&,
-	       const Reader::TextureIndices&) {}
-void Reader::l(const Reader::VertexIndices&,
-	       const Reader::NormalIndices&,
-	       const Reader::TextureIndices&) {}
-void Reader::p(const Reader::VertexIndices&,
-	       const Reader::NormalIndices&,
-	       const Reader::TextureIndices&) {}
-
-void Reader::newGroup(const std::string&) {}
-void Reader::activeGroups(const Reader::Strings&) {}
-void Reader::smoothingGroup(Reader::Id) {}
-void Reader::activeObject(const std::string&) {}
-void Reader::usemtl(const std::string&) {}
-void Reader::usemap(const std::string&) {}
-void Reader::mtllib(const std::string&) {}
-void Reader::maplib(const std::string&) {}
-void Reader::shadow_obj(const std::string&) {}
-void Reader::trace_obj(const std::string&) {}
-void Reader::lod(int) {}
-
-void Reader::bevel(bool) {}
-void Reader::cinterp(bool) {}
-void Reader::dinterp(bool) {}
-
-void
-Reader::parse(istream &i)
+namespace WFObj
 {
-    WFObjParse(i,this);
-    finished();
-}
+    using namespace std;
 
-bool
-Reader::parseFile(const char *filename)
-{
-    ifstream file(filename);
+    Reader::Reader() {}
 
-    if (file) 
+    Reader::~Reader() {}
+
+    void Reader::finished() {}
+
+    void Reader::v(float x, float y, float z) {}
+
+    void Reader::v(float x, float y, float z, float w) { v(x, y, z); }
+
+    void Reader::vt(float) {}
+
+    void Reader::vt(float, float) {}
+
+    void Reader::vt(float, float, float) {}
+
+    void Reader::vn(float, float, float) {}
+
+    void Reader::vp(float, float) {}
+
+    void Reader::vp(float) {}
+
+    void Reader::f(const Reader::VertexIndices&, const Reader::NormalIndices&,
+                   const Reader::TextureIndices&)
     {
-	parse(file);
-	return true;
     }
-    else
+
+    void Reader::l(const Reader::VertexIndices&, const Reader::NormalIndices&,
+                   const Reader::TextureIndices&)
     {
-	cerr << "Couldn't open the file " << filename << endl << flush;
-	return false;
     }
-}
 
+    void Reader::p(const Reader::VertexIndices&, const Reader::NormalIndices&,
+                   const Reader::TextureIndices&)
+    {
+    }
 
-} // WFObj
- 
+    void Reader::newGroup(const std::string&) {}
+
+    void Reader::activeGroups(const Reader::Strings&) {}
+
+    void Reader::smoothingGroup(Reader::Id) {}
+
+    void Reader::activeObject(const std::string&) {}
+
+    void Reader::usemtl(const std::string&) {}
+
+    void Reader::usemap(const std::string&) {}
+
+    void Reader::mtllib(const std::string&) {}
+
+    void Reader::maplib(const std::string&) {}
+
+    void Reader::shadow_obj(const std::string&) {}
+
+    void Reader::trace_obj(const std::string&) {}
+
+    void Reader::lod(int) {}
+
+    void Reader::bevel(bool) {}
+
+    void Reader::cinterp(bool) {}
+
+    void Reader::dinterp(bool) {}
+
+    void Reader::parse(istream& i)
+    {
+        WFObjParse(i, this);
+        finished();
+    }
+
+    bool Reader::parseFile(const char* filename)
+    {
+        ifstream file(filename);
+
+        if (file)
+        {
+            parse(file);
+            return true;
+        }
+        else
+        {
+            cerr << "Couldn't open the file " << filename << endl << flush;
+            return false;
+        }
+    }
+
+} // namespace WFObj

--- a/WFObj/Reader.h
+++ b/WFObj/Reader.h
@@ -18,129 +18,126 @@
 //******************************************************************************
 #ifndef __WFObj__Reader__h__
 #define __WFObj__Reader__h__
-#include <vector>
-#include <string>
 #include <iostream>
+#include <string>
+#include <vector>
 
-namespace WFObj {
-
-//
-//  The Reader class will call its own public virtual functions when
-//  its state changes during parsing. The default actions are to
-//  ignore everything.
-//
-
-class Reader
+namespace WFObj
 {
-  public:
-    Reader();
-    virtual ~Reader();
 
     //
-    //	Parse it. parseFile() returns false if it fails to open the file.
+    //  The Reader class will call its own public virtual functions when
+    //  its state changes during parsing. The default actions are to
+    //  ignore everything.
     //
 
-    virtual void parse(std::istream&i);
-    virtual bool parseFile(const char*);
+    class Reader
+    {
+    public:
+        Reader();
+        virtual ~Reader();
 
-    virtual void finished();
+        //
+        //	Parse it. parseFile() returns false if it fails to open the
+        // file.
+        //
 
-    //
-    //	types
-    //
+        virtual void parse(std::istream& i);
+        virtual bool parseFile(const char*);
 
-    typedef std::vector<int>		VertexIndices;
-    typedef std::vector<int>		NormalIndices;
-    typedef std::vector<int>		TextureIndices;
-    typedef std::vector<std::string>	Strings;
-    typedef int				Id;
-    
-    //
-    //	v? data
-    //
+        virtual void finished();
 
-    virtual void v(float,float,float);
-    virtual void v(float,float,float,float);
-    virtual void vt(float);
-    virtual void vt(float,float);
-    virtual void vt(float,float,float);
-    virtual void vn(float,float,float);
-    virtual void vp(float,float);
-    virtual void vp(float);
+        //
+        //	types
+        //
 
-    //
-    //	element data: faces / lines / points
-    //
+        typedef std::vector<int> VertexIndices;
+        typedef std::vector<int> NormalIndices;
+        typedef std::vector<int> TextureIndices;
+        typedef std::vector<std::string> Strings;
+        typedef int Id;
 
-    virtual void f(const VertexIndices&,
-		   const NormalIndices&,
-		   const TextureIndices&);
+        //
+        //	v? data
+        //
 
-    virtual void l(const VertexIndices&,
-		   const NormalIndices&,
-		   const TextureIndices&);
+        virtual void v(float, float, float);
+        virtual void v(float, float, float, float);
+        virtual void vt(float);
+        virtual void vt(float, float);
+        virtual void vt(float, float, float);
+        virtual void vn(float, float, float);
+        virtual void vp(float, float);
+        virtual void vp(float);
 
-    virtual void p(const VertexIndices&,
-		   const NormalIndices&,
-		   const TextureIndices&);
+        //
+        //	element data: faces / lines / points
+        //
 
-    //
-    //	Called when a group name is used that has not yet been seen
-    //
+        virtual void f(const VertexIndices&, const NormalIndices&,
+                       const TextureIndices&);
 
-    virtual void newGroup(const std::string&);
+        virtual void l(const VertexIndices&, const NormalIndices&,
+                       const TextureIndices&);
 
-    //
-    //	Called when active groups change
-    //
+        virtual void p(const VertexIndices&, const NormalIndices&,
+                       const TextureIndices&);
 
-    virtual void activeGroups(const Strings&);
+        //
+        //	Called when a group name is used that has not yet been seen
+        //
 
-    //
-    //	Called when an "o" line is encountered.
-    //
+        virtual void newGroup(const std::string&);
 
-    virtual void activeObject(const std::string&);
+        //
+        //	Called when active groups change
+        //
 
-    //
-    //	Called when smoothing group changes -- note that Id == 0 means
-    //	no smoothing -- this is equivalent to the "s off" statement.
-    //
+        virtual void activeGroups(const Strings&);
 
-    virtual void smoothingGroup(Id);
+        //
+        //	Called when an "o" line is encountered.
+        //
 
-    //
-    //	Bevel/cinterp/dinterp
-    //
+        virtual void activeObject(const std::string&);
 
-    virtual void bevel(bool);
-    virtual void cinterp(bool);
-    virtual void dinterp(bool);
+        //
+        //	Called when smoothing group changes -- note that Id == 0 means
+        //	no smoothing -- this is equivalent to the "s off" statement.
+        //
 
-    //
-    //	Material and map
-    //
+        virtual void smoothingGroup(Id);
 
-    virtual void mtllib(const std::string&);
-    virtual void maplib(const std::string&);
-    virtual void usemap(const std::string&);
-    virtual void usemtl(const std::string&);
+        //
+        //	Bevel/cinterp/dinterp
+        //
 
-    //
-    //	Trace/Shadow objects
+        virtual void bevel(bool);
+        virtual void cinterp(bool);
+        virtual void dinterp(bool);
 
-    virtual void trace_obj(const std::string&);
-    virtual void shadow_obj(const std::string&);
+        //
+        //	Material and map
+        //
 
-    //
-    //	Level of detail number
-    //
+        virtual void mtllib(const std::string&);
+        virtual void maplib(const std::string&);
+        virtual void usemap(const std::string&);
+        virtual void usemtl(const std::string&);
 
-    virtual void lod(int);
-};
+        //
+        //	Trace/Shadow objects
 
+        virtual void trace_obj(const std::string&);
+        virtual void shadow_obj(const std::string&);
 
-} // WFObj
+        //
+        //	Level of detail number
+        //
+
+        virtual void lod(int);
+    };
+
+} // namespace WFObj
 
 #endif // __WFObj__Reader__h__
-


### PR DESCRIPTION
As part of the initiative to enforce the code formatting with clang-format, this repository is formatted with the same .clang-format has the one in Open RV from this PR: https://github.com/AcademySoftwareFoundation/OpenRV/pull/645. Building Open RV with this submodule and [openrv-pub](https://github.com/shotgunsoftware/openrv-pub)